### PR TITLE
Adjusted player sizing for different breakpoints

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,20 +1,52 @@
-.player .video-container {
-    position: relative;
-    padding-bottom: 56.25%;
-    padding-top: 30px;
-    height: 0;
-    overflow: hidden;
+@media (max-width: 768px) {
+
+    .player .video-container {
+        position: relative;
+        padding-bottom: 56.25%;
+        padding-top: 30px;
+        height: 0;
+        overflow: hidden;
+    }
+
+    .player .video-container iframe, .video-container object, .video-container embed {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+
 }
 
-.player .video-container iframe, .video-container object, .video-container embed {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+@media (min-width: 769px) {
+    .main-wrapper {
+        padding: 10px 50px;
+    }
+
+    .player .video-container, .player h2 {
+        margin: 0 auto;
+        max-width: 640px;
+    }
 }
 
-.player h2 {
+.player {
     border-bottom: 1px solid black;
+    margin-bottom: 15px;
     padding-bottom: 15px;
+}
+
+.form-elements {
+    height: 45px;
+}
+
+.form-elements .form-inline {
+    float: left;
+}
+
+.form-elements .form-inline .form-control {
+    margin-right: 5px;
+}
+
+.form-elements .dropdown {
+    float: right;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -11,10 +11,12 @@ class App extends Component {
 
     render() {
         return (
-            <div className="main_wrapper">
+            <div className="main-wrapper">
                 <Player videoId={this.props.currentVideo.videoId} videoTitle={this.props.currentVideo.videoTitle}/>
-                <SearchField fetchVideo={this.props.fetchVideoData}/>
-                <SortingMenu/>
+                <div className='form-elements'>
+                    <SearchField fetchVideo={this.props.fetchVideoData}/>
+                    <SortingMenu/>
+                </div>
                 <VideoList videoData={this.props.videoData} selectVideo={this.props.updateCurrentVideo}/>
             </div>
         );


### PR DESCRIPTION
On devices smaller than 769px the player will take up the full width of the device. Otherwise it will remain at 640px width & 480px height, centered in the browser's window.